### PR TITLE
Fix: Bubbles would not appear on TDI / TDO channels until the analyzer was restarted

### DIFF
--- a/src/JtagAnalyzer.cpp
+++ b/src/JtagAnalyzer.cpp
@@ -194,9 +194,9 @@ void JtagAnalyzer::SetupResults()
 
     // set which channels will carry bubbles
     mResults->AddChannelBubblesWillAppearOn( mSettings.mTmsChannel );
-    if( mTdi != NULL )
+    if( mSettings.mTdiChannel != UNDEFINED_CHANNEL )
         mResults->AddChannelBubblesWillAppearOn( mSettings.mTdiChannel );
-    if( mTdo != NULL )
+    if( mSettings.mTdoChannel != UNDEFINED_CHANNEL )
         mResults->AddChannelBubblesWillAppearOn( mSettings.mTdoChannel );
 }
 


### PR DESCRIPTION
Simple issue, the mTdi/mTdo data members are not initialized when SetupResults() is called, they are set in Setup(), which is called at the top of the worker thread. Restarting the analyzer would fix this, as long as those channels were still in use.