### PR TITLE
FrameV2 support and output data before TMS stage shift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 project(jtag_analyzer)
 
-
+add_compile_definitions(LOGIC2)
 
 # enable generation of compile_commands.json, helpful for IDEs to locate include files.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/JtagAnalyzer.cpp
+++ b/src/JtagAnalyzer.cpp
@@ -34,7 +34,7 @@ void JtagAnalyzer::AdvanceTck( Frame& frm, JtagShiftedData& shifted_data )
         mTrst->AdvanceToNextEdge();
 
         // close the frame and add it
-        CloseFrame( frm, shifted_data, mTrst->GetSampleNumber() );
+        CloseFrameV2( frm, shifted_data, mTrst->GetSampleNumber() );
 
         // reset the TAP state
         mTAPCtrl.SetState( TestLogicReset );
@@ -76,7 +76,84 @@ void JtagAnalyzer::Setup()
         mTrst = NULL;
 }
 
-void JtagAnalyzer::CloseFrame( Frame& frm, JtagShiftedData& shifted_data, U64 ending_sample_number )
+std::vector<U8> BitsToBytes( std::vector<U8>& shifted_data )
+{
+    std::vector<U8> byteArray;
+
+    // get the numerical value from the bits
+    std::vector<U8>::const_iterator bsi( shifted_data.begin() );
+
+    U8 val;
+    size_t bits_remaining = shifted_data.size();
+
+    // make an array of 8 bit values
+    // e.g. for 10 bits, byteArray[0] would contain the first 2 bits
+    // and byteArray[1] would contain the next 8 bits.
+    for( ; bsi != shifted_data.end(); )
+    {
+        for( val = 0; bsi != shifted_data.end(); )
+        {
+            val = ( val << 1 ) | ( *bsi == BIT_HIGH ? 1 : 0 );
+            
+            --bits_remaining;
+            ++bsi;
+
+            if ((bits_remaining % 8) == 0)
+            {
+                // We've reached a byte boundary
+                break;
+            }
+        }
+
+        byteArray.emplace_back( val );
+    }
+
+    return byteArray;
+}
+
+void JtagAnalyzer::CloseFrameV2( Frame& frm, JtagShiftedData& shifted_data, U64 ending_sample_number )
+{
+    JtagShiftedData corrected_shifted_data;
+
+    CloseFrame( frm, shifted_data, ending_sample_number, &corrected_shifted_data );
+
+    FrameV2 frame_v2;
+
+    size_t max_bit_count = 0;
+
+    if( corrected_shifted_data.mTdiBits.size() > 0 )
+    {
+        std::vector<U8> data = BitsToBytes( corrected_shifted_data.mTdiBits );
+
+        frame_v2.AddByteArray( "TDI", &data[ 0 ], data.size() );
+
+        if (max_bit_count < corrected_shifted_data.mTdiBits.size() )
+        {
+            max_bit_count = corrected_shifted_data.mTdiBits.size();
+        }
+    }
+
+    if( corrected_shifted_data.mTdoBits.size() > 0 )
+    {
+        std::vector<U8> data = BitsToBytes( corrected_shifted_data.mTdoBits );
+
+        frame_v2.AddByteArray( "TDO", &data[ 0 ], data.size() );
+
+        if( max_bit_count < corrected_shifted_data.mTdoBits.size() )
+        {
+            max_bit_count = corrected_shifted_data.mTdoBits.size();
+        }
+    }
+
+    frame_v2.AddInteger( "BitCount", max_bit_count );
+
+    const char* type = JtagAnalyzerResults::GetStateDescShort( mTAPCtrl.GetCurrState() );
+
+    mResults->AddFrameV2( frame_v2, type,
+        frm.mStartingSampleInclusive, frm.mEndingSampleInclusive );
+}
+
+void JtagAnalyzer::CloseFrame( Frame& frm, JtagShiftedData& shifted_data, U64 ending_sample_number, JtagShiftedData* corrected_shifted_data )
 {
     // save the TDI/TDO values in the frame
     if( frm.mType == ShiftIR || frm.mType == ShiftDR )
@@ -90,6 +167,12 @@ void JtagAnalyzer::CloseFrame( Frame& frm, JtagShiftedData& shifted_data, U64 en
         }
 
         mResults->AddShiftedData( shifted_data );
+
+        if (corrected_shifted_data != NULL)
+        {
+            corrected_shifted_data->mTdiBits = shifted_data.mTdiBits;
+            corrected_shifted_data->mTdoBits = shifted_data.mTdoBits;
+        }
 
         shifted_data.mTdiBits.clear();
         shifted_data.mTdoBits.clear();
@@ -169,7 +252,7 @@ void JtagAnalyzer::WorkerThread()
             if( ( mSettings.mShiftDRBitsPerDataUnit != 0 ) && ( bitCount >= mSettings.mShiftDRBitsPerDataUnit ) )
             {
                 alreadyClosedFrame = true;
-                CloseFrame( frm, shifted_data, mTck->GetSampleNumber() );
+                CloseFrameV2( frm, shifted_data, mTck->GetSampleNumber() );
 
                 // prepare the next frame
                 frm.mStartingSampleInclusive = mTck->GetSampleNumber() + 1;
@@ -186,7 +269,7 @@ void JtagAnalyzer::WorkerThread()
         {
             mResults->AddMarker( mTms->GetSampleNumber(), AnalyzerResults::Dot, mSettings.mTmsChannel );
 
-            CloseFrame( frm, shifted_data, mTck->GetSampleNumber() );
+            CloseFrameV2( frm, shifted_data, mTck->GetSampleNumber() );
 
             // prepare the next frame
             frm.mStartingSampleInclusive = mTck->GetSampleNumber() + 1;

--- a/src/JtagAnalyzer.h
+++ b/src/JtagAnalyzer.h
@@ -29,7 +29,8 @@ class JtagAnalyzer : public Analyzer2
     void AdvanceTck( Frame& frm, JtagShiftedData& shifted_data );
 
     // closes the frame, and handles the tdi/tdo data
-    void CloseFrame( Frame& frm, JtagShiftedData& shifted_data, U64 ending_sample_number );
+    void CloseFrame( Frame& frm, JtagShiftedData& shifted_data, U64 ending_sample_number, JtagShiftedData* corrected_shifted_data = NULL );
+    void CloseFrameV2( Frame& frm, JtagShiftedData& shifted_data, U64 ending_sample_number );
 
   protected: // vars
     JtagAnalyzerSettings mSettings;

--- a/src/JtagAnalyzerSettings.cpp
+++ b/src/JtagAnalyzerSettings.cpp
@@ -13,7 +13,8 @@ JtagAnalyzerSettings::JtagAnalyzerSettings()
       mTAPInitialState( RunTestIdle ),
       mInstructRegBitOrder( LSB_First ),
       mDataRegBitOrder( LSB_First ),
-      mShowBitCount( false )
+      mShowBitCount( false ),
+      mShiftDRBitsPerDataUnit( 0 )
 {
     // init the interfaces
     mTmsChannelInterface.SetTitleAndTooltip( "TMS", "JTAG Test mode select" );
@@ -54,6 +55,11 @@ JtagAnalyzerSettings::JtagAnalyzerSettings()
     mDataRegBitOrderInterface.AddNumber( LSB_First, "Least significant bit first", "Data register shift LEAST significant bit first" );
     mDataRegBitOrderInterface.SetNumber( mDataRegBitOrder );
 
+    mShiftDRDataUnitInterface.SetTitleAndTooltip( "Shift-DR data unit", "Number of bits to report as a single data unit. 0 to only report when TAP state changes." );
+    mShiftDRDataUnitInterface.SetInteger( mShiftDRBitsPerDataUnit );
+    mShiftDRDataUnitInterface.SetMin( 0 );
+    mShiftDRDataUnitInterface.SetMax( 65536 );
+
     mShowBitCountInterface.SetTitleAndTooltip( "", "Used to count bits sent during Shift state" );
     mShowBitCountInterface.SetCheckBoxText( "Show TDI/TDO bit counts" );
     mShowBitCountInterface.SetValue( mShowBitCount );
@@ -68,6 +74,7 @@ JtagAnalyzerSettings::JtagAnalyzerSettings()
     AddInterface( &mTAPInitialStateInterface );
     AddInterface( &mInstructRegBitOrderInterface );
     AddInterface( &mDataRegBitOrderInterface );
+    AddInterface( &mShiftDRDataUnitInterface );
 
     AddInterface( &mShowBitCountInterface );
 
@@ -133,6 +140,8 @@ bool JtagAnalyzerSettings::SetSettingsFromInterfaces()
     cast2Int = int( mDataRegBitOrderInterface.GetNumber() );
     mDataRegBitOrder = BitOrder( cast2Int );
 
+    mShiftDRBitsPerDataUnit = mShiftDRDataUnitInterface.GetInteger();
+
     mShowBitCount = mShowBitCountInterface.GetValue();
 
     return true;
@@ -149,6 +158,7 @@ void JtagAnalyzerSettings::UpdateInterfacesFromSettings()
     mTAPInitialStateInterface.SetNumber( mTAPInitialState );
     mInstructRegBitOrderInterface.SetNumber( mInstructRegBitOrder );
     mDataRegBitOrderInterface.SetNumber( mDataRegBitOrder );
+    mShiftDRDataUnitInterface.SetInteger( mShiftDRBitsPerDataUnit );
     mShowBitCountInterface.SetValue( mShowBitCount );
 }
 
@@ -176,6 +186,10 @@ void JtagAnalyzerSettings::LoadSettings( const char* settings )
     if( ival == MSB_First || ival == LSB_First )
         mDataRegBitOrder = BitOrder( ival );
 
+    text_archive >> ival;
+    if( ( ival >= 0 ) && ( ival <= 65536 ) )
+        mShiftDRBitsPerDataUnit = ival;
+
     text_archive >> mShowBitCount; // added after 1.2.3. Defaults false on failure to load.
 
 
@@ -202,6 +216,7 @@ const char* JtagAnalyzerSettings::SaveSettings()
     text_archive << int( mTAPInitialState );
     text_archive << int( mInstructRegBitOrder );
     text_archive << int( mDataRegBitOrder );
+    text_archive << mShiftDRBitsPerDataUnit;
 
     text_archive << mShowBitCount; // added after 1.2.3
 

--- a/src/JtagAnalyzerSettings.h
+++ b/src/JtagAnalyzerSettings.h
@@ -37,6 +37,8 @@ class JtagAnalyzerSettings : public AnalyzerSettings
 
     bool mShowBitCount;
 
+    U32 mShiftDRBitsPerDataUnit;
+
   protected:
     AnalyzerSettingInterfaceChannel mTmsChannelInterface;
     AnalyzerSettingInterfaceChannel mTckChannelInterface;
@@ -48,6 +50,7 @@ class JtagAnalyzerSettings : public AnalyzerSettings
 
     AnalyzerSettingInterfaceNumberList mInstructRegBitOrderInterface;
     AnalyzerSettingInterfaceNumberList mDataRegBitOrderInterface;
+    AnalyzerSettingInterfaceInteger mShiftDRDataUnitInterface;
 
     AnalyzerSettingInterfaceBool mShowBitCountInterface;
 };


### PR DESCRIPTION
My goal here was to be able to write a High-Level analyzer for our development environment's debugger. The two problems were that this JTAG low-level analyzer doesn't output data until there is a state change. With our debugger, it remains in the Shift-DR state while debugging. So, I added the ability to chunk the data as it comes in, with the default value of "0" resulting in the same behavior as it currently provides. If changed to something like "8", then you get data output every 8 bits.

The second change is to output the data in a FrameV2 format for a python High-Level analyzer to be written.